### PR TITLE
Update Dataset.json documentation name

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -1175,7 +1175,7 @@
                 }
             ]
         },
-        "page": {
+        "documentation": {
             "$id": "http://xmlns.com/foaf/0.1/page",
             "title": "documentation",
             "description": "A page or document about this dataset",


### PR DESCRIPTION
According to https://doi-do.github.io/dcat-us/#dataset-documentation, the field should be called `documentation`.