### PR TITLE
Update all language definitions

### DIFF
--- a/jsonschema/definitions/Catalog.json
+++ b/jsonschema/definitions/Catalog.json
@@ -367,25 +367,20 @@
         "language": {
             "$id": "http://purl.org/dc/terms/language",
             "title": "language",
-            "description": "This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalog.",
+            "description": "This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalog. This should be provided as an ISO 639-1 language code, which can be seen at https://id.loc.gov/vocabulary/iso639-1.html",
             "oneOf": [
                 {
                     "type": "null"
                 },
                 {
+                    "type": "string",
+                    "maxLength": 2
+                },
+                {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/LinguisticSystem",
-                                "description": "inline description of LinguisticSystem"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of LinguisticSystem",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "maxLength": 2
                     }
                 }
             ]

--- a/jsonschema/definitions/CatalogRecord.json
+++ b/jsonschema/definitions/CatalogRecord.json
@@ -108,25 +108,20 @@
         "language": {
             "$id": "http://purl.org/dc/terms/language",
             "title": "language",
-            "description": "A language used in the textual metadata describing titles, descriptions, etc. of the Catalog Record.",
+            "description": "A language used in the textual metadata describing titles, descriptions, etc. of the Catalog Record. This should be provided as an ISO 639-1 language code, which can be seen at https://id.loc.gov/vocabulary/iso639-1.html",
             "oneOf": [
                 {
                     "type": "null"
                 },
                 {
+                    "type": "string",
+                    "maxLength": 2
+                },
+                {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/LinguisticSystem",
-                                "description": "inline description of LinguisticSystem"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of LinguisticSystem",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "maxLength": 2
                     }
                 }
             ]

--- a/jsonschema/definitions/DataService.json
+++ b/jsonschema/definitions/DataService.json
@@ -350,25 +350,20 @@
         "language": {
             "$id": "http://purl.org/dc/terms/language",
             "title": "language",
-            "description": "This property refers to a language supported by the Data Service. This property can be repeated if multiple languages are supported in the Data Service.",
+            "description": "This property refers to a language supported by the Data Service. This property can be repeated if multiple languages are supported in the Data Service. This should be provided as an ISO 639-1 language code, which can be seen at https://id.loc.gov/vocabulary/iso639-1.html",
             "oneOf": [
                 {
                     "type": "null"
                 },
                 {
+                    "type": "string",
+                    "maxLength": 2
+                },
+                {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/LinguisticSystem",
-                                "description": "inline description of LinguisticSystem"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of LinguisticSystem",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "maxLength": 2
                     }
                 }
             ]

--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -606,18 +606,18 @@
                 {
                     "type": "array",
                     "items": {
-						"oneOf": [
-							{
-								"$ref": "#/definitions/Standard",
-								"description": "inline description of Standard"
-							},
-							{
-								"type": "string",
-								"description": "reference iri of Standard",
-								"format": "iri"
-							}
-						]
-					}
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Standard",
+                                "description": "inline description of Standard"
+                            },
+                            {
+                                "type": "string",
+                                "description": "reference iri of Standard",
+                                "format": "iri"
+                            }
+                        ]
+                    }
                 }
             ]
         },
@@ -813,25 +813,20 @@
         "language": {
             "$id": "http://purl.org/dc/terms/language",
             "title": "language",
-            "description": "A language used in the Dataset.",
+            "description": "A language used in the Dataset. This should be provided as an ISO 639-1 language code, which can be seen at https://id.loc.gov/vocabulary/iso639-1.html",
             "oneOf": [
                 {
                     "type": "null"
                 },
                 {
+                    "type": "string",
+                    "maxLength": 2
+                },
+                {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/LinguisticSystem",
-                                "description": "inline description of LinguisticSystem"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of LinguisticSystem",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "maxLength": 2
                     }
                 }
             ]
@@ -1189,17 +1184,17 @@
                 {
                     "type": "array",
                     "items": {
-                       "oneOf": [
-                           {
-                               "$ref": "#/definitions/Document",
-                               "description": "inline description of Document"
-                           },
-                           {
-                               "type": "string",
-                               "description": "reference iri of Document",
-                               "format": "iri"
-                           }
-                       ]
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Document",
+                                "description": "inline description of Document"
+                            },
+                            {
+                                "type": "string",
+                                "description": "reference iri of Document",
+                                "format": "iri"
+                            }
+                        ]
                     }
                 }
             ]

--- a/jsonschema/definitions/Distribution.json
+++ b/jsonschema/definitions/Distribution.json
@@ -515,25 +515,20 @@
         "language": {
             "$id": "http://purl.org/dc/terms/language",
             "title": "language",
-            "description": "A language used in the Distribution.",
+            "description": "A language used in the Distribution. This should be provided as an ISO 639-1 language code, which can be seen at https://id.loc.gov/vocabulary/iso639-1.html",
             "oneOf": [
                 {
                     "type": "null"
                 },
                 {
+                    "type": "string",
+                    "maxLength": 2
+                },
+                {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/LinguisticSystem",
-                                "description": "inline description of LinguisticSystem"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of LinguisticSystem",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "maxLength": 2
                     }
                 }
             ]


### PR DESCRIPTION
Related to https://github.com/GSA/dcat-us/issues/3.

Update all language definitions to be a string with 2 characters, and reference the iso link and ID.

Please note original link definition of `#/definitions/LinguisticSystem` does not exist, and is unnecessary.